### PR TITLE
Finished fixing up ^xRBG bugs, so that where displayed incorrectly, i…

### DIFF
--- a/codemp/cgame/cg_draw.cpp
+++ b/codemp/cgame/cg_draw.cpp
@@ -33,6 +33,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // Jedi Knight Galaxies
 #include "jkg_hud.h"
+#include "jkg_chatbox.h"
 
 extern float CG_RadiusForCent( centity_t *cent );
 qboolean CG_WorldCoordToScreenCoordFloat(vec3_t worldCoord, float *x, float *y);
@@ -1676,10 +1677,19 @@ static float CG_DrawEnemyInfo ( float y )
 
 	y += size;
 
-	CG_Text_Paint( 630 - CG_Text_Width ( ci->name, 1.0f, FONT_SMALL2 ) + xOffset, y, 1.0f, colorWhite, ci->name, 0, 0, 0, FONT_SMALL2 );
+
+	//I have no idea what this is lol - maybe leaderboard thing that shows up in the top right of jka?  --futuza
+	//CG_Text_Paint( 630 - CG_Text_Width ( ci->name, 1.0f, FONT_SMALL2 ) + xOffset, y, 1.0f, colorWhite, ci->name, 0, 0, 0, FONT_SMALL2 );	//futuza note: old way
+	Text_DrawText(630 - Text_GetWidth(ci->name, FONT_SMALL2, 1.0f) + xOffset, y, ci->name, colorWhite, FONT_SMALL2, 0, 1.0f);				//futuza note: new way
 
 	y += 15;
-	CG_Text_Paint( 630 - CG_Text_Width ( title, 1.0f, FONT_SMALL2 ) + xOffset, y, 1.0f, colorWhite, title, 0, 0, 0, FONT_SMALL2 );
+	//note might want to change this back, title's probably can't use color codes anyway
+	//CG_Text_Paint( 630 - CG_Text_Width ( title, 1.0f, FONT_SMALL2 ) + xOffset, y, 1.0f, colorWhite, title, 0, 0, 0, FONT_SMALL2 );			//futuza note: old way
+	Text_DrawText(630 - Text_GetWidth(title, FONT_SMALL2, 1.0f) + xOffset, y, title, colorWhite, FONT_SMALL2, 0, 1.0f);							//futuza note: new way
+
+	//ohhh is this dueling only?
+	//okay okay
+	
 
 	return y + BIGCHAR_HEIGHT + 2;
 }
@@ -2362,7 +2372,7 @@ static void CG_DrawTeamOverlay() {
 		if ( ci->infoValid && (( cgs.party.active && TeamFriendly( i )) || ( !cgs.party.active && ci->team == cg.snap->ps.persistant[PERS_TEAM] )))
 		{
 			plyrs++;
-			len = (float)trap->R_Font_StrLenPixels(ci->name, MenuFontToHandle(1), 1) *0.5f; //CG_DrawStrlen(ci->name);
+			len = (float)trap->R_Font_StrLenPixels(Text_ConvertExtToNormal(ci->name), MenuFontToHandle(1), 1) *0.5f; //CG_DrawStrlen(ci->name);		//futuza note: deals with filling in the actual space and figuring out how wide to make it
 			if (len > pwidth)
 				pwidth = len;
 		}
@@ -2423,9 +2433,11 @@ static void CG_DrawTeamOverlay() {
 			MAKERGBA(hcolor,0,0,0,1);
 			CG_DrawRect(x+2, y+2, 20, 20, 1, hcolor);
 
+
 			// Draw player name
 			MAKERGBA(hcolor,1,1,1,1);		
-			trap->R_Font_DrawString(x+26, y+2, ci->name, hcolor, MenuFontToHandle(1) | 0x80000000, -1, 0.5f);		//--futuza notes: drawing player names
+			//trap->R_Font_DrawString(x+26, y+2, ci->name, hcolor, MenuFontToHandle(1) | 0x80000000, -1, 0.5f);		//old way
+			Text_DrawText(x + 26, y + 2, ci->name, hcolor, MenuFontToHandle(1) | 0x80000000, -1, 0.5f);		// futuza note: xRBG color code fix for teamoverlay
 			MAKERGBA(hcolor,0,0,0,1);
 			CG_DrawRect(x+24, y+2, pwidth+8 , 13, 1, hcolor);
 
@@ -5591,8 +5603,8 @@ static void CG_DrawCrosshairNames( void ) {
 	tcolor[2] = colorTable[baseColor][2];
 	tcolor[3] = color[3]*0.5f;
 
-	CG_SanitizeString(name, sanitized);
-
+	//CG_SanitizeString(JKG_xRBG_ConvertExtToNormal(name), sanitized);				//"fixed" not really (q_shared.h now has a const and non-const version) ehhh whatever this is safe enough
+	CG_SanitizeString(const_cast<char*>(JKG_xRBG_ConvertExtToNormal(name)), sanitized); //fixme, why const_cast why!? wow. such unsafe. very hack. maybe not so bad? http://stackoverflow.com/questions/856542/elegant-solution-to-duplicate-const-and-non-const-getters
 	if (isVeh)
 	{
 		char str[MAX_STRING_CHARS];

--- a/codemp/cgame/cg_event.cpp
+++ b/codemp/cgame/cg_event.cpp
@@ -128,8 +128,8 @@ static void CG_Obituary( entityState_t *ent ) {
 	char		*message;
 	const char	*targetInfo;
 	const char	*attackerInfo;
-	char		targetName[32];
-	char		attackerName[32];
+	char		targetName[MAX_QPATH];						//increased from 32, to use MAX_QPATH standards people standards
+	char		attackerName[MAX_QPATH];
 	gender_t	gender;
 	clientInfo_t	*ci;
 
@@ -143,6 +143,7 @@ static void CG_Obituary( entityState_t *ent ) {
 	}
 	ci = &cgs.clientinfo[target];
 
+
 	if ( attacker < 0 || attacker >= MAX_CLIENTS ) {
 		attacker = ENTITYNUM_WORLD;
 		attackerInfo = NULL;
@@ -154,7 +155,7 @@ static void CG_Obituary( entityState_t *ent ) {
 	if ( !targetInfo ) {
 		return;
 	}
-	Q_strncpyz( targetName, Info_ValueForKey( targetInfo, "n" ), sizeof(targetName) - 2);
+	Q_strncpyz( targetName, Info_ValueForKey( targetInfo, "n" ), sizeof(targetName) - 2);			//--futuza note:  possible RBG color fix needed here on targetName
 	strcat( targetName, S_COLOR_WHITE );
 
 	// check for single client messages
@@ -289,7 +290,7 @@ clientkilled:
 				trap->SE_GetStringTextString("MP_INGAME_PLACE_WITH",     sPlaceWith, sizeof(sPlaceWith));
 				trap->SE_GetStringTextString("MP_INGAME_KILLED_MESSAGE", sKilledStr, sizeof(sKilledStr));
 
-				s = va("%s %s.\n%s %s %i.", sKilledStr, targetName, 
+				s = va("%s %s.\n%s %s %i.", sKilledStr, JKG_xRBG_ConvertExtToNormal(targetName),			//--futuza: ^xRBG name fix
 					CG_PlaceString( cg.snap->ps.persistant[PERS_RANK] + 1 ), 
 					sPlaceWith,
 					cg.snap->ps.persistant[PERS_SCORE] );
@@ -297,7 +298,7 @@ clientkilled:
 		} else {
 			char sKilledStr[256];
 			trap->SE_GetStringTextString("MP_INGAME_KILLED_MESSAGE", sKilledStr, sizeof(sKilledStr));
-			s = va("%s %s", sKilledStr, targetName );
+			s = va("%s %s", sKilledStr, JKG_xRBG_ConvertExtToNormal(targetName));						//--futuza: ^xRBG name fix
 		}
 
 		CG_CenterPrint( s, SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH );
@@ -307,7 +308,7 @@ clientkilled:
 	// check for double client messages
 	if ( !attackerInfo ) {
 		attacker = ENTITYNUM_WORLD;
-		strcpy( attackerName, "noname" );
+		strcpy( attackerName, "noname" );																	//--futuza: possible RBG color name fix needed
 	} else {
 		Q_strncpyz( attackerName, Info_ValueForKey( attackerInfo, "n" ), sizeof(attackerName) - 2);
 		strcat( attackerName, S_COLOR_WHITE );
@@ -418,14 +419,14 @@ clientkilled:
 			message = (char *)CG_GetStringEdString("MP_INGAME", message);
 			if (jkg_nokillmessages.integer!=1) {
 				trap->Print( "%s %s %s\n", 
-				targetName, message, attackerName); //Disables rendering of kill messages as it is not needed in a MMO?
+					JKG_xRBG_ConvertExtToNormal(targetName), message, JKG_xRBG_ConvertExtToNormal(attackerName)); //Disables rendering of kill messages as it is not needed in a MMO?	//--futuza: ^xRBG fix
 			}
 			return;
 		}
 	}
 	if (jkg_nokillmessages.integer!=1) {
 		// we don't know what it was
-		trap->Print( "%s %s\n", targetName, (char *)CG_GetStringEdString("MP_INGAME", "DIED_GENERIC") );  //Disables rendering of kill messages as it is not needed in a MMO?
+		trap->Print("%s %s\n", JKG_xRBG_ConvertExtToNormal(targetName), (char *)CG_GetStringEdString("MP_INGAME", "DIED_GENERIC"));  //Disables rendering of kill messages as it is not needed in a MMO?  //--futuza: ^xRBG fix
 	}
 }
 
@@ -758,7 +759,7 @@ void CG_PrintCTFMessage(clientInfo_t *ci, const char *teamName, int ctfMessage)
 
 			if (ci)
 			{
-				Com_sprintf(printMsg, sizeof(printMsg), "%s^7 ", ci->name);
+				Com_sprintf(printMsg, sizeof(printMsg), "%s^7 ", JKG_xRBG_ConvertExtToNormal(ci->name));	//--futuza: possible ^xRBG fix, needs testing, but this concerns ctf
 				strLen = strlen(printMsg);
 			}
 
@@ -790,7 +791,7 @@ void CG_PrintCTFMessage(clientInfo_t *ci, const char *teamName, int ctfMessage)
 
 	if (ci)
 	{
-		Com_sprintf(printMsg, sizeof(printMsg), "%s^7 %s", ci->name, psStringEDString);
+		Com_sprintf(printMsg, sizeof(printMsg), "%s^7 %s", JKG_xRBG_ConvertExtToNormal(ci->name), psStringEDString);
 	}
 	else
 	{
@@ -2580,6 +2581,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 	//
 	// other events
 	//
+	//Player teleporting
 	case EV_PLAYER_TELEPORT_IN:
 		DEBUGNAME("EV_PLAYER_TELEPORT_IN");
 		/*{
@@ -3022,7 +3024,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position ) {
 				{ //add to the chat box
 					//hear it in the world spot.
 					char vchatstr[1024];
-					strcpy(vchatstr, va("<%s: %s>\n", ci->name, descr));
+					strcpy(vchatstr, va("<%s: %s>\n", JKG_xRBG_ConvertExtToNormal(ci->name), descr));	//futuza: fixed xRBB color codes
 					if (jkg_nokillmessages.integer!=1) {
 					trap->Print(vchatstr); //Disables rendering of kill messages as it is not needed in a MMO?
 					}

--- a/codemp/cgame/cg_scoreboard.cpp
+++ b/codemp/cgame/cg_scoreboard.cpp
@@ -203,9 +203,8 @@ static void CG_DrawClientScore( int y, score_t *score, float *color, float fade,
 
 
 	vec4_t dummy;	//dummy float to pass into dumb function, because it's dumb.  
-
 	Text_DrawText(SB_NAME_X, y, ci->name, dummy, FONT_MEDIUM, -1, 0.9f*scale);	//new better way, allows us to use RBG colors
-	//CG_Text_Paint(SB_NAME_X, y, 0.9f * scale, colorWhite, Text_ConvertExtToNormal(ci->name), 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM);	//old way of drawing scoreboard names
+	//CG_Text_Paint(SB_NAME_X, y, 0.9f * scale, colorWhite, ci->name, 0, 0, ITEM_TEXTSTYLE_OUTLINED, FONT_MEDIUM);	//old way of drawing scoreboard names
 
 	if ( score->ping != -1 )
 	{

--- a/codemp/cgame/jkg_chatbox.h
+++ b/codemp/cgame/jkg_chatbox.h
@@ -19,7 +19,7 @@
 
 float Text_GetWidth(const char *text, int iFontIndex, float scale);		//figure out our text's width
 static float ExtColor_GetLevel(char chr);
-static int Text_ExtColorCodes(const char *text, vec4_t color);			
+static int Text_ExtColorCodes(const char *text, vec4_t color);			//actually figures out RBG of a ^xRBG name
 const char *Text_ConvertExtToNormal(const char *text);				//convert RBG colors to normal colors
 void Text_DrawText(int x, int y, const char *text, const float* rgba, int iFontIndex, const int limit, float scale);	//draw text on screen
 

--- a/codemp/cgame/jkg_chatcmds.h
+++ b/codemp/cgame/jkg_chatcmds.h
@@ -15,6 +15,9 @@
 // Heavily based on the engine's command tokenizer
 // Copyright (c) 2013 Jedi Knight Galaxies
 
+#ifndef CGAME_JKG_CHATCMDS_H
+#define CGAME_JKG_CHATCMDS_H
+
 typedef void (*xccommand_t) ( void );
 
 
@@ -31,3 +34,5 @@ void	CCmd_AddCommand( const char *cmd_name, xccommand_t function );
 void	CCmd_RemoveCommand( const char *cmd_name );
 
 void Text_DrawText(int x, int y, const char *text, const float* rgba, int iFontIndex, const int limit, float scale);
+
+#endif

--- a/codemp/game/jkg_chatcmds.h
+++ b/codemp/game/jkg_chatcmds.h
@@ -6,6 +6,9 @@
 //
 //////////////////////////////////
 
+#ifndef GAME_JKG_CHATCMDS_H
+#define GAME_JKG_CHATCMDS_H
+
 typedef void (*xccommand_t) (void);
 
 
@@ -21,3 +24,5 @@ void	CCmd_AddCommand( const char *cmd_name, xccommand_t function );
 void	CCmd_RemoveCommand( const char *cmd_name );
 int CCmd_Caller( void );
 char *CCmd_ConcatArgs( int start );
+
+#endif

--- a/codemp/qcommon/q_shared.c
+++ b/codemp/qcommon/q_shared.c
@@ -1903,3 +1903,158 @@ qboolean Text_IsExtColorCode(const char *text) {
 	return qtrue;
 }
 
+
+/*
+====================================================================
+//JKG Extended ^xRBG Color Codes adopted from jkg_chatbox.cpp
+====================================================================  
+So far only JKG_xRBG_ConvertExtToNormal() can be used.  Might add some more from jkg_chatbox.h later
+
+*/
+static vec4_t tColorTable[10] = 
+{
+	{ 0, 0, 0, 1 }, // ^0
+	{ 1, 0, 0, 1 }, // ^1
+	{ 0, 1, 0, 1 }, // ^2
+	{ 1, 1, 0, 1 }, // ^3
+	{ 0, 0, 1, 1 }, // ^4
+	{ 0, 1, 1, 1 }, // ^5
+	{ 1, 0, 1, 1 }, // ^6
+	{ 1, 1, 1, 1 }, // ^7
+	{ 0, 0, 0, 1 }, // ^8
+	{ 1, 0, 0, 1 }  // ^9
+};
+
+static float ExtColor_GetLevel(char chr) 
+{
+	if (chr >= '0' && chr <= '9') {
+		return ((float)(chr - '0') / 15.0f);
+	}
+	if (chr >= 'A' && chr <= 'F') {
+		return ((float)(chr - 'A' + 10) / 15.0f);
+	}
+	if (chr >= 'a' && chr <= 'f') {
+		return ((float)(chr - 'a' + 10) / 15.0f);
+	}
+	return -1;
+}
+
+static int Text_ExtColorCodes(const char *text, vec4_t color) 
+{
+	const char *r, *g, *b;
+	float red, green, blue;
+	r = text + 1;
+	g = text + 2;
+	b = text + 3;
+	// Get the color levels (if the numbers are invalid, it'll return -1, which we can use to validate)
+	red = ExtColor_GetLevel(*r);
+	green = ExtColor_GetLevel(*g);
+	blue = ExtColor_GetLevel(*b);
+	// Determine if all 3 are valid
+	if (red == -1 || green == -1 || blue == -1) {
+		return 0;
+	}
+
+	// We're clear to go, lets construct our color
+
+	color[0] = red;
+	color[1] = green;
+	color[2] = blue;
+
+	// HACK: Since cgame will use a palette override to implement dynamic opacity (like the chatbox)
+	// we must ensure we use that alpha as well.
+	// So copy the alpha of colorcode 0 (^0) instead of assuming 1.0
+
+	//color[3] =*(float *)(0x56DF54 /*0x56DF48 + 12*/);
+	color[3] = 1.0f;
+	return 1;
+}
+
+// This function converts a text with extended color codes (^xRGB) into a text with normal color codes
+// The extended colors will be clamped so the closest normal color available
+// Used to display text with extended colorcodes in the console
+
+const char *JKG_xRBG_ConvertExtToNormal(const char *text)	//for converting ^xRBG names to regular ^1names
+{
+	static char buff[2048];
+	const char *r;		// Reader
+	char *w;			// Writer
+	char *cutoff;
+	vec4_t color;
+	int hicolors;
+	int i;
+	r = text;
+	w = buff;
+	cutoff = &buff[2046];
+	while (*r) {
+		if (w >= cutoff) {
+			// Time to stop, we reached the limit
+			*w = 0;
+			return &buff[0];
+		}
+		if (*r == '^' && *(r + 1) == 'x') {
+			if (Text_ExtColorCodes(r + 1, color)) {
+				// Extended colorcode alright, determine which base color is closest to this one
+				*w = *r;	// write the ^
+				w++;
+				r += 5;
+
+				// Determine how many of the R G and B components are over 50%
+				hicolors = 0;
+				for (i = 0; i<3; i++) {
+					if (color[i] >= 0.5f) {
+						hicolors++;
+					}
+				}
+				switch (hicolors) {
+				case 0:
+					// Color is black
+					*w = '0';
+					break;
+				case 1:
+					// It's a primary color, find out which
+					if (color[0] >= 0.5f) {
+						// It's red
+						*w = '1';
+					}
+					else if (color[1] >= 0.5f) {
+						// It's green
+						*w = '2';
+					}
+					else {
+						// Must be blue
+						*w = '4';
+					}
+					break;
+				case 2:
+					// It's a secondary color, find out which
+					if (color[0] >= 0.5f && color[1] >= 0.5f) {
+						// It's yellow
+						*w = '3';
+					}
+					else if (color[1] >= 0.5f && color[2] >= 0.5f) {
+						// It's cyan
+						*w = '5';
+					}
+					else {
+						// Must be purple
+						*w = '6';
+					}
+					break;
+				case 3:
+					// Color is white
+					*w = '7';
+					break;
+				default:
+					assert(0);	// Never happens, telling the compiler so
+				}
+				w++;
+				continue;
+			}
+		}
+		*w = *r;
+		r++; w++;
+	}
+	*w = *r;	// Write the null terminator
+	return &buff[0];
+}

--- a/codemp/qcommon/q_shared.h
+++ b/codemp/qcommon/q_shared.h
@@ -2513,6 +2513,7 @@ void JKG_ClearGenericMemoryObject(GenericMemoryObject *gmo);
 void JKG_GenericMemoryObject_AddElement(GenericMemoryObject *gmo, void *element);
 void JKG_GenericMemoryObject_DeleteElement(GenericMemoryObject *gmo, unsigned int number);
 void Q_RGBCopy( vec4_t *output, vec4_t source );
+const char *JKG_xRBG_ConvertExtToNormal(const char *text);	//for converting ^xRBG names to regular ^1names  kind of hacky
 qboolean Text_IsExtColorCode(const char *text);
 qboolean StringContainsWord(const char *haystack, const char *needle);
 qboolean Q_stratt( char *dest, unsigned int iSize, char *source );

--- a/codemp/ui/jkg_partymanager.cpp
+++ b/codemp/ui/jkg_partymanager.cpp
@@ -8,6 +8,8 @@
 //
 ////////////////////////////////////////////////////////////
 
+
+//todo: futuza fix ^xRBG names using JKG_xRBG_ConvertExtToNormal() from q_shared.h
 #include "ui_local.h"
 
 // UI includes

--- a/codemp/ui/jkg_pazaak.cpp
+++ b/codemp/ui/jkg_pazaak.cpp
@@ -8,6 +8,16 @@
 //
 ////////////////////////////////////////////////////////////
 
+//--futuza todo:
+/*
+1. Ask the player being challenged to pazaak to accept without freezing them up.  eg: "challenger->name has challenged you to a round of Pazaak, accept?  y/n" Server gives player 10 seconds, before assuming a no.
+2. Typing in /y will accept the match and proceed as normal.
+3. Typing in /n will decline the match
+4. If challenged by more than one person within the 10 second grace period, system will respond to new challengers with, "Sorry this person has already been challenged by another opponent, ask them again later."
+5. When you accept a match, toggle god mode on for both players/make invincible.  This will be a server cfg setting, that can be turned on/off (so if it is a problem, people can't cheat using pazaak for invincibility in a match).
+6. When match finishes, turn off god mode.
+*/
+
 #include "ui_shared.h"
 #include "ui_local.h"
 
@@ -874,10 +884,10 @@ void JKG_Pazaak_DrawNames(int player, float x, float y, float w, float h) {
 		text = PzkState.name_opponent;
 	}
 	if (player == 2) {
-		width = (float)trap->R_Font_StrLenPixels(text, MenuFontToHandle(1), 1) * 0.5;
+		width = (float)trap->R_Font_StrLenPixels(JKG_xRBG_ConvertExtToNormal(text), MenuFontToHandle(1), 1) * 0.5;	//--futuza: ^xRBG fix
 		x=x-width;
 	}
-	trap->R_Font_DrawString(	x, y , text, colorWhite, MenuFontToHandle(1), -1, 0.5);
+	trap->R_Font_DrawString(x, y, JKG_xRBG_ConvertExtToNormal(text), colorWhite, MenuFontToHandle(1), -1, 0.5);		//--futuza: ^xRBG fix
 }
 
 void JKG_Pazaak_DrawPoints(int player, float x, float y, float w, float h) {


### PR DESCRIPTION
…t should show full color names.  Now works with kill information, welcome messages, team join messages, scoreboard, pazaak, and more.  Also tweaked a few things such as setting the kill message max length to be equal to the name length so they aren't getting truncated.

Note also added some useful features from jkg_chatbox.h to q_shared.h such as the probably overused and needs a cleaner solution function: JKG_xRBG_ConvertExtToNormal()

There is one change I'm unsure about, that while it fixes the problem may be potentially unsafe.  See cgame/cg_draw.cpp's line 5607 "CG_SanitizeString(const_cast<char*>(JKG_xRBG_ConvertExtToNormal(name)), sanitized);" in which I use a scary const_cast.  I can't think of a better way to do it though.