### PR TITLE
SanitizeString and RGB fixes

### DIFF
--- a/codemp/cgame/cg_draw.cpp
+++ b/codemp/cgame/cg_draw.cpp
@@ -5429,8 +5429,8 @@ void CG_DrawNPCNames( void )
 
 		//CG_Printf("%i screen coords are %fx%f. (%f %f %f)\n", cent->currentState.number, x, y, origin[0], origin[1], origin[2]);
 
-		CG_SanitizeString(str1, sanitized1);
-		CG_SanitizeString(str2, sanitized2);
+		CG_SanitizeString(str1, sanitized1);		//--futuza: Global_SanitizeString
+		CG_SanitizeString(str2, sanitized2);		
 		
 		size = dist * 0.0002;
 		
@@ -5609,7 +5609,7 @@ static void CG_DrawCrosshairNames( void ) {
 	tcolor[2] = colorTable[baseColor][2];
 	tcolor[3] = color[3]*0.5f;
 
-	CG_SanitizeString(name, sanitized);												//--futuza note: changed CG_SanitizeString() to allow ^xRGB names
+	CG_SanitizeString(name, sanitized);												//--futuza note: please replace with: Global_SanitizeString
 	if (isVeh)
 	{
 		char str[MAX_STRING_CHARS];

--- a/codemp/cgame/cg_draw.cpp
+++ b/codemp/cgame/cg_draw.cpp
@@ -2840,7 +2840,7 @@ CENTER PRINTING
 ===============================================================================
 */
 
-#define CG_CP_NUMBER_OF_CHARACTERS_IN_LINE	50
+#define CG_CP_NUMBER_OF_CHARACTERS_IN_LINE	75		//--futuza: original value 50
 
 /*
 ==============
@@ -4602,11 +4602,17 @@ void CG_SanitizeString( char *in, char *out )
 				i += 2;
 				continue;
 			}
-			else if (in[i + 1] == 'x' || in[i + 1] == 'X')		//if an extended RGB color code
+			else if (in[i + 1] == 'x' || in[i + 1] == 'X')		//if an extended RGB color code  note: needs safety checking
 			{
-				i += 5;
+				for (int l = 2; l < 7; l++)
+				{
+					if (in[i + l] == NULL)
+						;					//if we hit end of string do nothing
+					else
+						i++;
+				}
+				//i += 5;
 				continue;
-			}
 			else
 			{ //just skip the ^
 				i++;
@@ -5429,8 +5435,10 @@ void CG_DrawNPCNames( void )
 
 		//CG_Printf("%i screen coords are %fx%f. (%f %f %f)\n", cent->currentState.number, x, y, origin[0], origin[1], origin[2]);
 
-		CG_SanitizeString(str1, sanitized1);		//--futuza: Global_SanitizeString
-		CG_SanitizeString(str2, sanitized2);		
+		//CG_SanitizeString(str1, sanitized1);		//--futuza: Global_SanitizeString
+		//CG_SanitizeString(str2, sanitized2);
+		Global_SanitizeString(str1, sanitized1, 128);
+		Global_SanitizeString(str2, sanitized2, 128);
 		
 		size = dist * 0.0002;
 		
@@ -5609,7 +5617,8 @@ static void CG_DrawCrosshairNames( void ) {
 	tcolor[2] = colorTable[baseColor][2];
 	tcolor[3] = color[3]*0.5f;
 
-	CG_SanitizeString(name, sanitized);												//--futuza note: please replace with: Global_SanitizeString
+	//CG_SanitizeString(name, sanitized);												//--futuza note: please replace with: Global_SanitizeString
+	Global_SanitizeString(name, sanitized, 128);
 	if (isVeh)
 	{
 		char str[MAX_STRING_CHARS];

--- a/codemp/game/g_cmds.cpp
+++ b/codemp/game/g_cmds.cpp
@@ -2997,7 +2997,15 @@ void SanitizeString2( char *in, char *out )
 			}
 			else if (in[i + 1] == 'x' || in[i + 1] == 'X')		//if an extended RGB color code
 			{
-				i += 5;
+
+				for (int l = 2; l < 7; l++)
+				{
+					if (in[i + l] == NULL)
+						;					//if we hit end of string do nothing
+					else
+						i++;
+				}
+				//i += 5;
 				continue;
 			}
 			else
@@ -3037,12 +3045,14 @@ int G_ClientNumberFromStrippedName ( const char* name )
 	gclient_t*	cl;
 
 	// check for a name match
-	SanitizeString2( (char*)name, s2 );			//futuza: Global_SanitizeString
+	//SanitizeString2( (char*)name, s2 );			//futuza: Global_SanitizeString
+	Global_SanitizeString((char*)name, s2, MAX_NAME_LENGTH);		//fixed
 	Q_strlwr(s2);
 	for ( i=0; i < level.numConnectedClients ; i++ ) 
 	{
 		cl = &level.clients[level.sortedClients[i]];
-		SanitizeString2( cl->pers.netname, n2 );
+		//SanitizeString2( cl->pers.netname, n2 );
+		Global_SanitizeString(cl->pers.netname, n2, MAX_NAME_LENGTH);
 		Q_strlwr(n2);
 		if ( !strcmp( n2, s2 ) ) 
 		{
@@ -3226,12 +3236,14 @@ int G_ClientNumberFromStrippedSubstring ( const char* name, qboolean checkAll )
 	gclient_t	*cl;
 
 	// check for a name match
-	SanitizeString2( (char*)name, s2 );			//futuza: Global_SanitizeString
+	//SanitizeString2( (char*)name, s2 );			//futuza: Global_SanitizeString
+	Global_SanitizeString((char*)name, s2, MAX_NAME_LENGTH);
 	Q_strlwr(s2);
 	for ( i=0 ; i < level.numConnectedClients ; i++ ) 
 	{
 		cl = &level.clients[level.sortedClients[i]];
-		SanitizeString2( cl->pers.netname, n2 );
+		//SanitizeString2( cl->pers.netname, n2 );
+		Global_SanitizeString(cl->pers.netname, n2, MAX_NAME_LENGTH);
 		Q_strlwr(n2);
 		if ( strstr( n2, s2 ) ) 
 		{

--- a/codemp/game/g_cmds.cpp
+++ b/codemp/game/g_cmds.cpp
@@ -509,6 +509,8 @@ JKGStringType_t JKG_CheckIfNumber(const char *string)
 SanitizeString
 
 Remove case and control characters
+
+//futuza: todo replace this with Global_SanitizeString if possible, note this also removes case so we have to account for that
 ==================
 */
 void SanitizeString( char *in, char *out ) {
@@ -3035,7 +3037,7 @@ int G_ClientNumberFromStrippedName ( const char* name )
 	gclient_t*	cl;
 
 	// check for a name match
-	SanitizeString2( (char*)name, s2 );
+	SanitizeString2( (char*)name, s2 );			//futuza: Global_SanitizeString
 	Q_strlwr(s2);
 	for ( i=0; i < level.numConnectedClients ; i++ ) 
 	{
@@ -3224,7 +3226,7 @@ int G_ClientNumberFromStrippedSubstring ( const char* name, qboolean checkAll )
 	gclient_t	*cl;
 
 	// check for a name match
-	SanitizeString2( (char*)name, s2 );
+	SanitizeString2( (char*)name, s2 );			//futuza: Global_SanitizeString
 	Q_strlwr(s2);
 	for ( i=0 ; i < level.numConnectedClients ; i++ ) 
 	{

--- a/codemp/game/jkg_admin.cpp
+++ b/codemp/game/jkg_admin.cpp
@@ -89,7 +89,7 @@ static const char *SanitizeName( const char *name ) {
 
 	idx++;
 	idx &= 3;
-	SanitizeString2((char *)name, &clean[idx][0]);
+	SanitizeString2((char *)name, &clean[idx][0]);	//--futuza: use this instead Global_SanitizeString()
 	return clean[idx];
 }
 

--- a/codemp/game/jkg_admin.cpp
+++ b/codemp/game/jkg_admin.cpp
@@ -89,8 +89,10 @@ static const char *SanitizeName( const char *name ) {
 
 	idx++;
 	idx &= 3;
-	SanitizeString2((char *)name, &clean[idx][0]);	//--futuza: use this instead Global_SanitizeString()
+	//SanitizeString2((char *)name, &clean[idx][0]);	//--futuza: use this instead Global_SanitizeString()
+	Global_SanitizeString((char *)name, &clean[idx][0], MAX_NAME_LENGTH);
 	return clean[idx];
+	
 }
 
 static const char	*Cmd_ConcatArgs( int start ) {

--- a/codemp/qcommon/q_shared.c
+++ b/codemp/qcommon/q_shared.c
@@ -2060,9 +2060,14 @@ char *JKG_xRBG_ConvertExtToNormal(const char *text)	//for converting ^xRBG names
 	return &buff[0];
 }
 
+//didn't provide a limit value okay?
+void Global_SanitizeString(char *in, char *out)
+{
+	Global_SanitizeString(in, out, MAX_QPATH);
+}
 
-//got sick of rewritting SanitizeString() functions, so here's a global one		--futuza  todo: change every single damn sanitizestring() call to refer to this one
-void Global_SanitizeString(char *in, char *out, int limit = MAX_QPATH) //note: users can optionally pass in a limit value, rather then using the default
+//got sick of rewritting SanitizeString() functions, so here's a global one		--futuza  todo: remove references to other SanitizeString functions
+void Global_SanitizeString(char *in, char *out, int limit) //note: users can optionally pass in a limit value, rather then using the default
 {
 	int i = 0;
 	int r = 0;
@@ -2082,9 +2087,16 @@ void Global_SanitizeString(char *in, char *out, int limit = MAX_QPATH) //note: u
 				i += 2;
 				continue;
 			}
-			else if (in[i + 1] == 'x' || in[i + 1] == 'X')		//if an extended RGB color code
+			else if (in[i + 1] == 'x' || in[i + 1] == 'X')		//if an extended RGB color code  note: needs safety checking
 			{
-				i += 5;
+				for (int l = 2; l < 7; l++)
+				{
+					if (in[i + l] == NULL)
+						;					//if we hit end of string do nothing
+					else
+						i++;
+				}
+				//i += 5;
 				continue;
 			}
 			else
@@ -2094,7 +2106,7 @@ void Global_SanitizeString(char *in, char *out, int limit = MAX_QPATH) //note: u
 			}
 		}
 
-		if (in[i] < 32)
+		if (in[i] < 32)		//if a control character?
 		{
 			i++;
 			continue;

--- a/codemp/qcommon/q_shared.h
+++ b/codemp/qcommon/q_shared.h
@@ -2514,6 +2514,7 @@ void JKG_GenericMemoryObject_AddElement(GenericMemoryObject *gmo, void *element)
 void JKG_GenericMemoryObject_DeleteElement(GenericMemoryObject *gmo, unsigned int number);
 void Q_RGBCopy( vec4_t *output, vec4_t source );
 char *JKG_xRBG_ConvertExtToNormal(const char *text);	//for converting ^xRGB names to regular ^1names return nonconst
+void Global_SanitizeString(char *in, char *out);
 void Global_SanitizeString(char *in, char *out, int limit);
 qboolean Text_IsExtColorCode(const char *text);
 qboolean StringContainsWord(const char *haystack, const char *needle);

--- a/codemp/rd-common/tr_font.cpp
+++ b/codemp/rd-common/tr_font.cpp
@@ -1416,7 +1416,7 @@ int RE_Font_StrLenPixels(const char *psText, const int iFontHandle, const float 
 //
 int RE_Font_StrLenChars(const char *psText)
 {
-	// logic for this function's letter counting must be kept same in this function and RE_Font_DrawString(), also CG_SanitizeString() in cg_draw.cpp
+	// logic for this function's letter counting must be kept same in this function and RE_Font_DrawString(), also CG_SanitizeString()/Global_SanitizeString() in cg_draw.cpp and q_shared.c
 	//
 	int iCharCount = 0;
 


### PR DESCRIPTION
Improved SanitizeString functions with a global version and extended center print buffer to make room for RGB functions.   Todo: remove (most of the) old sanitizestring functions since they're no longer needed.