### PR TITLE
Attempting to fix console text for ^xRGB codes.  Not yet done, curren…

### DIFF
--- a/codemp/qcommon/q_shared.c
+++ b/codemp/qcommon/q_shared.c
@@ -2049,7 +2049,7 @@ char *JKG_xRBG_ConvertExtToNormal(const char *text)	//for converting ^xRBG names
 			*w = 0;
 			return &buff[0];
 		}
-		if (*r == '^' && *(r + 1) == 'x') {
+		if (*r == '^' && (*(r + 1) == 'x' || *(r + 1) == 'X')) {
 			if (Text_ExtColorCodes(r + 1, color)) {
 				// Extended colorcode alright, determine which base color is closest to this one
 				*w = *r;	// write the ^

--- a/codemp/qcommon/q_shared.h
+++ b/codemp/qcommon/q_shared.h
@@ -2514,6 +2514,7 @@ void JKG_GenericMemoryObject_AddElement(GenericMemoryObject *gmo, void *element)
 void JKG_GenericMemoryObject_DeleteElement(GenericMemoryObject *gmo, unsigned int number);
 void Q_RGBCopy( vec4_t *output, vec4_t source );
 static qboolean ExtColor_IsValid(char chr);			//check if ^xRGB valid, returns -1 if not valid
+//static float ExtColor_GetLevel(char chr);			//get color values for ^xRGB
 void Q_StripColor_Simple(char *text);				//simplifying strip mining operations
 char *JKG_xRBG_ConvertExtToNormal(const char *text);	//for converting ^xRGB names to regular ^1names return nonconst
 void Global_SanitizeString(char *in, char *out);


### PR DESCRIPTION
…tly doesn't change color, but does truncate xrgb strings.  Need to come up with good solution for setting color or revert to not do anything for ^xRGBs