### PR TITLE
Default fs_basegame to JKG

### DIFF
--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -3347,7 +3347,7 @@ void FS_Startup( const char *gameName ) {
 	fs_copyfiles = Cvar_Get( "fs_copyfiles", "0", CVAR_INIT );
 	fs_cdpath = Cvar_Get ("fs_cdpath", "", CVAR_INIT|CVAR_PROTECTED );
 	fs_basepath = Cvar_Get ("fs_basepath", Sys_DefaultInstallPath(), CVAR_INIT|CVAR_PROTECTED );
-	fs_basegame = Cvar_Get ("fs_basegame", "", CVAR_INIT );
+	fs_basegame = Cvar_Get ("fs_basegame", "JKG", CVAR_INIT );
 	homePath = Sys_DefaultHomePath();
 	if (!homePath || !homePath[0]) {
 		homePath = fs_basepath->string;


### PR DESCRIPTION
Defaults fs_basegame to JKG. This still allows fs_game to be set in case people want to make mods on top of JKG.