### PR TITLE
Fix Travis CI macOS build

### DIFF
--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -122,8 +122,9 @@ list(APPEND MPVanillaRendererLibraries          ${ZLIB_LIBRARIES})
 list(APPEND MPVanillaRendererIncludeDirectories ${MINIZIP_INCLUDE_DIRS})
 list(APPEND MPVanillaRendererLibraries          ${MINIZIP_LIBRARIES})
 
-message(STATUS "PNG Include Dirs: ${PNG_INCLUDE_DIRS}")
-message(STATUS "PNG Libraries: ${PNG_LIBRARIES}")
+message(STATUS "PNG_INCLUDE_DIRS: ${PNG_INCLUDE_DIRS}")
+message(STATUS "PNG_INCLUDE_DIR: ${PNG_INCLUDE_DIR}")
+message(STATUS "PNG_LIBRARIES: ${PNG_LIBRARIES}")
 
 
 find_package(OpenGL REQUIRED)

--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -122,6 +122,9 @@ list(APPEND MPVanillaRendererLibraries          ${ZLIB_LIBRARIES})
 list(APPEND MPVanillaRendererIncludeDirectories ${MINIZIP_INCLUDE_DIRS})
 list(APPEND MPVanillaRendererLibraries          ${MINIZIP_LIBRARIES})
 
+message(STATUS "PNG Include Dirs: ${PNG_INCLUDE_DIRS}")
+message(STATUS "PNG Libraries: ${PNG_LIBRARIES}")
+
 
 find_package(OpenGL REQUIRED)
 set(MPVanillaRendererIncludeDirectories ${MPVanillaRendererIncludeDirectories} ${OPENGL_INCLUDE_DIR})

--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -111,7 +111,12 @@ list(APPEND MPVanillaRendererLibraries          ${JPEG_LIBRARIES})
 
 # Transparently use either bundled or system libpng.  Order is important --
 # libpng used zlib, so it must come before it on the linker command line.
-list(APPEND MPVanillaRendererIncludeDirectories ${PNG_INCLUDE_DIRS})
+#
+# Adding PNG_INCLUDE_DIRS and PNG_INCLUDE_DIR because the former can be empty
+# even when the latter contains a path. With PNG_INCLUDE_DIR marked as
+# deprecated, it's safer to have both in case PNG_INCLUDE_DIR stops working
+# and PNG_INCLUDE_DIRS starts working.
+list(APPEND MPVanillaRendererIncludeDirectories ${PNG_INCLUDE_DIRS} ${PNG_INCLUDE_DIR})
 list(APPEND MPVanillaRendererLibraries          ${PNG_LIBRARIES})
 
 # Transparently use either bundled or system zlib.
@@ -121,11 +126,6 @@ list(APPEND MPVanillaRendererLibraries          ${ZLIB_LIBRARIES})
 # Transparently use our bundled minizip.
 list(APPEND MPVanillaRendererIncludeDirectories ${MINIZIP_INCLUDE_DIRS})
 list(APPEND MPVanillaRendererLibraries          ${MINIZIP_LIBRARIES})
-
-message(STATUS "PNG_INCLUDE_DIRS: ${PNG_INCLUDE_DIRS}")
-message(STATUS "PNG_INCLUDE_DIR: ${PNG_INCLUDE_DIR}")
-message(STATUS "PNG_LIBRARIES: ${PNG_LIBRARIES}")
-
 
 find_package(OpenGL REQUIRED)
 set(MPVanillaRendererIncludeDirectories ${MPVanillaRendererIncludeDirectories} ${OPENGL_INCLUDE_DIR})

--- a/tools/travis-build.sh
+++ b/tools/travis-build.sh
@@ -40,6 +40,6 @@ set -- -D CMAKE_BUILD_TYPE="$flavour" "$@"
 ( cd build && cmake \
 	-D CMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
 	"$@" .. )
-make -C build
+make -C build VERBOSE=1
 make -C build install
 ( cd $(pwd)/build/${INSTALL_DIR} && find . -ls )


### PR DESCRIPTION
For some reason on the Travis CI macOS builds, `PNG_INCLUDE_DIRS` is empty even when it should be identical to `PNG_INCLUDE_DIR`. As a result compilation fails since `png.h` cannot be found.

This PR adds `PNG_INCLUDE_DIR` to the include directory which does have the include path for `png.h`. Since `PNG_INCLUDE_DIR` is marked for deprecation and may stop working, we continue to use `PNG_INCLUDE_DIRS` as well since this is documented as the correct variable to use for include directories.